### PR TITLE
Update LevelDB module to support multiple Level-* backends

### DIFF
--- a/leveldb_db.js
+++ b/leveldb_db.js
@@ -19,7 +19,7 @@
  * See http://code.google.com/p/leveldb/ for information about LevelDB
  * 
  * LevelDB must be installed in order to use this database.
- * Install it using npm install leveldb
+ * Install it using npm install hyperlevel or npm install level-hyper
  * 
  * Options:
  *   directory: The LevelDB directory, defaults to "leveldb-store"
@@ -31,11 +31,20 @@
  */
 try
 {
-  var leveldb = require("leveldb");
+		// default leveldb binding
+  var leveldb = require("level")
+  		// hyperlevel fork
+  		|| require("hyperlevel")
+  		|| require("level-hyper")
+  		// basholevel fork
+  		|| require("basholevel")
+  		|| require("level-basho")
+  		// old binding
+  		|| require("leveldb")
 }
 catch(e)
 {
-  console.error("FATAL: The leveldb dependency could not be loaded.");
+  console.error("FATAL: The level dependency could not be found. Please install one using npm from the following: level, hyperlevel, level-hyper, basholevel, level-basho.");
   process.exit(1);
 }
 


### PR DESCRIPTION
Some level-backends feature better resource handling and performance.
This includes *basholevel* (*level-basho*), *hyperlevel* (*level-hyper*), *level* and the pretty much deprecated *leveldb*.

— Please note when using Etherpad —

If level is used — regardless of whether this is merged or not — a user has to patch PadManager.js in order to make the API work. This is incurs the following changes:

Until a PR implements a readStream interface to *ueberDB*'s level-module, we have to drop-in replace *ueberDB*'s exposed findKeys with a direct passthru-readStream to the underlying level-engine. (this can, but doesn't have to be, as explained my other PR, an explicit levelDB-engine or any leveldown compatible ABI binding to node).

PadManager.js => init: function(); find and replace:

	db.findKeys("pad:*", "*:*:*", function(err, dbData) {
		if (ERR(err, cb)) return;
		if (dbData != null) {
			padList.initiated = true
			dbData.forEach(function(val) {
				padList.addPad(val.replace(/pad:/, ""), false);
			});
			cb && cb()
		}
	});

with

        db.db.wrappedDB.db
                .createReadStream({start: "pad:", end: "pad:\xFF", values: false})
                .on("data", function (val) {
                        padList.initiated = true
                        val.split(":").length === 2
                                && padList.addPad(val.replace(/pad:/, ""), false);
                })
                .on("end", function () {
                        cb && cb()
                })

I hope I can spare time to implement this readStream as findKeys.