### PR TITLE
Adding support for Cassandra CQL3

### DIFF
--- a/CacheAndBufferLayer.js
+++ b/CacheAndBufferLayer.js
@@ -156,7 +156,15 @@ exports.database.prototype.get = function(key, callback)
     var self = this;
   
     this.wrappedDB.get(key, function(err,value)
-    {  
+    {
+      if (err)
+      {
+        console.error("QUERY-ERROR: key = " + key);
+        console.error(err.stack || util.inspect(err));
+        callback(err);
+        return;
+      }
+
       if(self.settings.json)
       {
         try
@@ -165,7 +173,7 @@ exports.database.prototype.get = function(key, callback)
         }
         catch(e)
         {
-          console.error("JSON-PROBLEM:" + value);
+          console.error("JSON-PROBLEM: value = " + value);
           callback(e);
           return;
         }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Abstract your databases, make datababies.  ueberDB turns every database into a s
 * Mongo
 * Redis
 * Couch
-* Cassandra
+* Cassandra (CQL2)
+* Cassandra (CQL3)
 
 #Install
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -16,6 +16,7 @@
 
 var async = require("async");
 var ueberDB = require("./CloneAndAtomicLayer");
+var util = require("util");
 
 //settings
 var maxValues = 100000;
@@ -49,7 +50,7 @@ if(process.argv.length == 3)
     console.log("finished");
     console.log("time: " +  time + "s");
     process.exit(0);
-  })  
+  });
 }
 
 //the benchmark function
@@ -232,12 +233,12 @@ function doOperations(operations, measure, callback)
       {
          measureTime(function(callback)
          {
-           db.set(item.key, item.value, null, callback);
+           db.set(item.key, item.value, null, errorReporterCallback(item, callback));
          },item.type, callback);
       }
       else
       {
-        db.set(item.key, item.value, null, callback);
+        db.set(item.key, item.value, null, errorReporterCallback(item, callback));
       }  
     }
     else if(item.type == "read")
@@ -246,11 +247,11 @@ function doOperations(operations, measure, callback)
       {
         measureTime(function(callback){
           db.get(item.key, callback);
-        },item.type, callback); 
+        },item.type, errorReporterCallback(item, callback));
       }
       else
       {
-        db.get(item.key, callback);
+        db.get(item.key, errorReporterCallback(item, callback));
       }
     }
     else if(item.type == "delete")
@@ -259,11 +260,11 @@ function doOperations(operations, measure, callback)
       {
         measureTime(function(callback){
           db.remove(item.key, null, callback);
-        },item.type, callback); 
+        },item.type, errorReporterCallback(item, callback));
       }
       else
       {
-        db.remove(item.key, null, callback);
+        db.remove(item.key, null, errorReporterCallback(item, callback));
       }
     }
     else
@@ -314,6 +315,20 @@ function measureTime(func, type, callback){
     
     callback(err);
   });
+}
+
+// Create a callback that will log important information if an
+// ueberDB query results in an error
+function errorReporterCallback(op, callback) {
+  return function(err) {
+    if (err) {
+      console.error('error executing operation:');
+      console.error(util.inspect(op));
+      console.error(err.stack);
+    }
+
+    callback(err);
+  };
 }
 
 var lastRands = [];

--- a/cassandra/README_cassandra_cql2_to_cql3_compact.md
+++ b/cassandra/README_cassandra_cql2_to_cql3_compact.md
@@ -1,0 +1,42 @@
+The Cassandra CQL3 Compact driver (`cassandra_cql3_compact_db.js`) is backward compatible with the CQL2 driver (`cassandra_db.js`). Though there is one change needed to the schema to make it work. In cassandra-cli, issue the following statement in your keyspace:
+
+```
+use <keyspace name>;
+UPDATE COLUMN FAMILY <etherpad column family name> WITH column_metadata = [];
+```
+
+This command simply updates the metadata of the column family, it *does not* edit data within the column family. This change will trigger CQL3 to identify this column family as a *dynamic column family* with *wide rows* rather than a *static column family*. To verify that it had the intended effect, we can describe the column family using cqlsh in CQL3 mode:
+
+```
+~/Source/ueberDB$ cqlsh -3
+Connected to test at localhost:9160.
+[cqlsh 3.1.7 | Cassandra 1.2.11-SNAPSHOT | CQL spec 3.0.0 | Thrift protocol 19.36.1]
+Use HELP for help.
+cqlsh> describe keyspace <keyspace name>;
+
+CREATE KEYSPACE <keyspace name> WITH replication = {
+  'class': 'SimpleStrategy',
+  'replication_factor': '1'
+};
+
+USE <keyspace name>;
+
+CREATE TABLE <column family name> (
+  key text,
+  column1 text,
+  value text,
+  PRIMARY KEY (key, column1)
+) WITH COMPACT STORAGE AND
+  bloom_filter_fp_chance=0.010000 AND
+  caching='KEYS_ONLY' AND
+  comment='' AND
+  dclocal_read_repair_chance=0.000000 AND
+  gc_grace_seconds=864000 AND
+  read_repair_chance=0.100000 AND
+  replicate_on_write='true' AND
+  populate_io_cache_on_flush='false' AND
+  compaction={'class': 'SizeTieredCompactionStrategy'} AND
+  compression={'sstable_compression': 'SnappyCompressor'};
+```
+
+The key change in the table definition is that it has **3 columns: (key text, column1 text, value text)**.

--- a/cassandra/util.js
+++ b/cassandra/util.js
@@ -1,0 +1,96 @@
+
+var helenus = require('helenus');
+
+/**
+ * Use the ueberDB database settings object to create the helenus configuration object
+ * for initializing the cassandra connection pool.
+ *
+ * @param  {Object}   settings    The ueberDB database configuration
+ * @return {Object}               The Helenus ConnectionPool configuration
+ * @throws {Error}                If the configuration is invalid or missing required parameters
+ */
+var createConfig = module.exports.createConfig = function(settings) {
+  if (!settings.hosts || settings.hosts.length === 0) {
+    throw new Error('The Cassandra hosts should be defined.');
+  }
+  if (!settings.keyspace) {
+    throw new Error('The Cassandra keyspace should be defined.');
+  }
+  if (!settings.cfName) {
+    throw new Error('The Cassandra column family should be defined.');
+  }
+
+  var config = {};
+  config.hosts = settings.hosts;
+  config.keyspace = settings.keyspace;
+  config.cfName = settings.cfName;
+  if (settings.user) {
+    config.user = settings.user;
+  }
+  if (settings.pass) {
+    config.pass = settings.pass;
+  }
+  config.timeout = parseInt(settings.timeout, 10) || 3000;
+  config.replication = parseInt(settings.replication, 10) || 1;
+  config.strategyClass = settings.strategyClass || 'SimpleStrategy';
+  return config;
+};
+
+/**
+ * Initialize the helenus ConnectionPool using the helenus configuration. The ColumnFamily
+ * for the etherpad content will be created if it does not already exist, using the
+ * provided `createCfQuery` parameter.
+ *
+ * @param  {Object}   config                    The Helenus ConnectionPool configuration object
+ * @param  {Object}   createCfQuery             The query data to create the CF, if needed
+ * @param  {String}   createCfQuery.cql         The CQL query that will create the CF
+ * @param  {Array}    createCfQuery.parameters  The parameters for the CQL query
+ * @param  {Function} callback                  Invoked when the pool is initialized
+ * @param  {Error}    callback.err              An error that occurred, if any
+ */
+var initPool = module.exports.initPool = function(config, createCfQuery, callback) {
+  // Create pool
+  var pool = new helenus.ConnectionPool(config);
+  pool.on('error', function(err) {
+    // We can't use the callback method here, as this is a generic error handler.
+    console.error(err);
+  });
+
+  // Connect to it.
+  pool.connect(function(err) {
+    if (err) {
+      return callback(err);
+    }
+
+    // Get a description of the keyspace so we can determine whether or not the CF exist.
+    pool.getConnection()._client.describe_keyspace(config.keyspace, function(err, definition) {
+      if (err && err.name) {
+        // If the keyspace doesn't exist, an error will be promoted here
+        return callback(err);
+      }
+
+      // Iterate over all the column families and check if the desired one exists.
+      var exists = false;
+      definition.cf_defs.forEach(function(cf) {
+        if (cf.name === config.cfName) {
+          exists = true;
+        }
+      });
+
+      if (exists) {
+        // The CF exists, we're done here.
+        callback(null, pool);
+      } else {
+        // Create the CF
+        pool.cql(createCfQuery.cql, createCfQuery.parameters, function(err) {
+          if (err) {
+            callback(err);
+            return;
+          }
+
+          callback(null, pool);
+        });
+      }
+    });
+  });
+};

--- a/defaultTestSettings.js
+++ b/defaultTestSettings.js
@@ -6,3 +6,4 @@ exports["redis"] = {};
 exports["couch"] = {port: 5984, host: 'localhost', database: "etherpadlite", maxListeners: 0};
 exports["mongodb"] = {port: 27017, host: "localhost", dbname: "etherpadlite"};
 exports["cassandra"] = {hosts: ["127.0.0.1:9160"], keyspace: "etherpadlite", cfName: "etherpadlite"};
+exports["cassandra_cql3_compact"] = {hosts: ["127.0.0.1:9160"], keyspace: "etherpadlite", cfName: "etherpadlite"};

--- a/removeTest.js
+++ b/removeTest.js
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var async = require('async');
+var ueberDB = require("./CloneAndAtomicLayer");
+var log4js = require('log4js');
+var assert = require('assert');
+var util = require("util");
+
+var test_settings = require("./defaultTestSettings.js");
+var db = null;
+
+// Validate parameters
+if(process.argv.length == 3)
+{
+  var settings = test_settings[process.argv[2]];
+}
+else
+{
+  console.error("Invalid parameters");
+  process.exit(1);
+}
+
+
+async.series(
+  [
+
+    // initialize the database
+    function(callback)
+    {
+      console.log("initializing database");
+      db = new ueberDB.database(process.argv[2], settings, null, log4js.getLogger("ueberDB"));
+      db.init(callback);
+    },
+
+    // ensure keys that are added are properly deleted after
+    function(callback)
+    {
+      console.log("executing test");
+      console.log("Setting: test_remove = test_remove");
+
+      // set a value
+      db.db.wrappedDB.set("test_remove", "test_remove", function(err)
+      {
+        assert.ok(!err);
+
+        // ensure it is there
+        db.db.wrappedDB.get("test_remove", function(err, value)
+        {
+          assert.ok(!err);
+          assert.strictEqual(value, "test_remove");
+
+          console.log("Set was successful");
+          console.log("Removing: test_remove");
+
+          // remove it
+          db.db.wrappedDB.remove("test_remove", function(err)
+          {
+            assert.ok(!err);
+
+            // ensure it is no longer there
+            db.db.wrappedDB.get("test_remove", function(err, value)
+            {
+              assert.ok(!err);
+              assert.strictEqual(value, null);
+
+              console.log("Remove was successful");
+
+              callback();
+            });
+          });
+        });
+      });
+    }
+  ],
+  function(err) {
+    assert.ok(!err);
+    console.log("Test complete");
+    process.exit(0);
+  }
+);


### PR DESCRIPTION
Adding a CQL3 driver that is backward compatible with cassandra_db.js (CQL2)
by using a compact storage table.

I have named this driver `cassandra_cql3_compact.js` in anticipation that the
"defacto" CQL3 driver would use the newer non-compact CQL3 storage model,
and would likely want to `cassandra_cql3.js`.

Also added a test to get coverage on the `remove` function. Note the
documentation on how to upgrade from `cassandra` to `cassandra_cql3_compact`,
as there is a necessary schema statement for it to work.

Migration was validated manually using etherpad as the ueberDB consumer.
