### PR TITLE
Possibility of disabling serialization to json

### DIFF
--- a/mongodb_db.js
+++ b/mongodb_db.js
@@ -26,7 +26,7 @@ exports.database = function (settings) {
     this.settings = settings;
     this.settings.cache = 1000;
     this.settings.writeInterval = 100;
-    this.settings.json = true;
+    this.settings.json = settings.json || true;
     
 }
 


### PR DESCRIPTION
Hello, 
I know this isn't a bug 
but what is the reason to serialize data to json before saving to mongoDB?

I feel that this is overhead on saving/loading time.
(Or maybe add possibility of adding custom db drivers)