### PR TITLE
actually use the callbacks in setSub

### DIFF
--- a/CacheAndBufferLayer.js
+++ b/CacheAndBufferLayer.js
@@ -317,15 +317,16 @@ exports.database.prototype.setSub = function(key, sub, value, bufferCallback, wr
       subvalueParent[sub[sub.length-1]] = value;
       
       _this.set(key, fullValue, bufferCallback, writeCallback);
+      callback(null);
     }
   ],function(err)
   {
-    if(bufferCallback || writeCallback)
+    if(err)
     {
       if(bufferCallback) bufferCallback(err);
-      if(writeCallback) writeCallback(err);
+      else if(writeCallback) writeCallback(err);
+      else throw err;
     }
-    else if(err != null) throw err;
   })
 }
 

--- a/CacheAndBufferLayer.js
+++ b/CacheAndBufferLayer.js
@@ -320,7 +320,11 @@ exports.database.prototype.setSub = function(key, sub, value, bufferCallback, wr
     }
   ],function(err)
   {
-    if(callback) callback(err);
+    if(bufferCallback || writeCallback)
+    {
+      if(bufferCallback) bufferCallback(err);
+      if(writeCallback) writeCallback(err);
+    }
     else if(err != null) throw err;
   })
 }


### PR DESCRIPTION
During research on https://github.com/ether/etherpad-lite/issues/2522 I came across this one.

```
[2015-03-13 21:28:50.106] [ERROR] console - ReferenceError: callback is not defined
    at /home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/CacheAndBufferLayer.js:334:8
    at /home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/async/lib/async.js:436:21
    at /home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/CacheAndBufferLayer.js:170:11
    at Query._callback (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/mysql_db.js:115:5)
    at Query.Sequence.end (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/protocol/sequences/Sequence.js:96:24)
    at Query._handleFinalResultPacket (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/protocol/sequences/Query.js:143:8)  
    at Query.EofPacket (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/protocol/sequences/Query.js:127:8)
    at Protocol._parsePacket (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/protocol/Protocol.js:271:23)
    at Parser.write (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/protocol/Parser.js:77:12)
    at Protocol.write (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/protocol/Protocol.js:39:16)
    at Socket.<anonymous> (/home/etherpad-lite-tests/ethercleanclean/src/node_modules/ueberDB/node_modules/mysql/lib/Connection.js:82:28)
```

bcb1f256dcc3893a5aa0f55eda6050473fdaa11c removed the function parameter `callback`
The PR fixes the referenceError but it's too hard for me to dig into writing tests for ueberDB right now... If details to reproduce the bug are needed or if I misunderstood the intention behind the code here, just comment/mail me.
