### PR TITLE
add findKeys method for CouchDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
                       { "name": "spcsser"}
                      ],
   "dependencies"   : {
-                       "mysql"     : ">=2.5.1",
-                       "dirty"     : "0.9.x",
-                       "async"     : "0.1.15",
-                       "channels"  : "0.0.2",
-                       "redis"     : ">=0.12.1",
-                       "pg"        : ">=4.0.0-beta2",
-                       "helenus"   : "0.6.10"
+                       "mysql"          : ">=2.5.1",
+                       "dirty"          : "0.9.x",
+                       "async"          : "0.1.15",
+                       "channels"       : "0.0.2",
+                       "redis"          : ">=0.12.1",
+                       "pg"             : ">=4.0.0-beta2",
+                       "helenus"        : "0.6.10",
+                       "felix-couchdb"  : "^1.0.7"
                      },
   "devDependencies": {
                        "log4js"    : "0.4.1",


### PR DESCRIPTION
Hi,

I'v added the findKeys methods for being able to use the `listAllPads` methods of Etherpad.

Also the *felix-couchdb* was missing in the package.json. 
And about *felix-couchdb*, it was also broken for me… so I made a [pull request](https://github.com/felixge/node-couchdb/pull/53) in order to make it work. Without this patch, this module will sadly throw errors :disappointed: 
