### PR TITLE
[fix] Do not raise error if no callback is provided on "remove" operation

### DIFF
--- a/CloneAndAtomicLayer.js
+++ b/CloneAndAtomicLayer.js
@@ -35,8 +35,8 @@ exports.database = function(type, dbSettings, wrapperSettings, logger)
   //saves all settings and require the db module
   this.type = type;
   this.db_module = require("./" + type + "_db");
-  this.dbSettings = dbSettings; 
-  this.wrapperSettings = wrapperSettings; 
+  this.dbSettings = dbSettings;
+  this.wrapperSettings = wrapperSettings;
   this.logger = logger || defaultLogger;
   this.channels = new channels.channels(doOperation);
 }
@@ -95,10 +95,10 @@ function doOperation (operation, callback)
     {
       //clone the value
       value = clone(value);
-      
+
       //call the caller callback
       operation.callback(err, value);
-      
+
       //call the queue callback
       callback();
     });
@@ -106,8 +106,10 @@ function doOperation (operation, callback)
   else if(operation.type == "remove"){
     operation.db.remove(operation.key, function(err)
     {
+      //call the caller callback
+      if(operation.callback) operation.callback(err);
+
       //call the queue callback
-      operation.callback(err);
       callback();
     });
   }
@@ -117,21 +119,21 @@ function doOperation (operation, callback)
     {
       //clone the value
       value = clone(value);
-      
+
       //call the caller callback
       operation.callback(err, value);
-      
+
       //call the queue callback
       callback();
     });
   }
   else if(operation.type == "set")
-  {  
+  {
     operation.db.set(operation.key, operation.value, function(err)
     {
       //call the queue callback
       callback();
-      
+
       //call the caller callback
       if(operation.bufferCallback) operation.bufferCallback(err);
     }, operation.writeCallback);
@@ -142,10 +144,10 @@ function doOperation (operation, callback)
     {
       //clone the value
       value = clone(value);
-      
+
       //call the caller callback
       operation.callback(err, value);
-      
+
       //call the queue callback
       callback();
     });
@@ -156,7 +158,7 @@ function doOperation (operation, callback)
     {
       //call the queue callback
       callback();
-      
+
       //call the caller callback
       if(operation.bufferCallback) operation.bufferCallback(err);
     }, operation.writeCallback);

--- a/tests/CloneAndAtomicLayer.js
+++ b/tests/CloneAndAtomicLayer.js
@@ -1,0 +1,55 @@
+var expect = require('expect.js');
+
+var defaultTestSettings = require('../defaultTestSettings.js');
+var ueberDB             = require('../CloneAndAtomicLayer');
+
+describe('.doOperation()', function() {
+  context('when operation is "remove"', function() {
+    var KEY = 'the key';
+
+    var db;
+
+    before(function(done) {
+      // using mongodb only because there are other tests already configured to
+      // use it, but could be any DB type
+      db = new ueberDB.database('mongodb', defaultTestSettings.mongodb);
+      db.init(done);
+    });
+
+    after(function(done) {
+      db.close(done);
+    });
+
+    beforeEach(function(done) {
+      // create a value to be removed on the tests
+      db.set(KEY, 'any value', null, done);
+    });
+
+    context('when a callback is provided', function() {
+      it('removes the value and calls the callback', function(done) {
+        db.remove(KEY, function() {
+          db.findKeys(KEY, null, function(err, keysFound) {
+            expect(keysFound).to.have.length(0);
+            done();
+          });
+        });
+      });
+    });
+
+    // this scenario is important because some clients (like Etherpad) do not provide a
+    // callback when calling the "remove" operation
+    context('when no callback is provided', function() {
+      it('removes the value', function(done) {
+        db.remove(KEY);
+
+        // give some time for the value to be removed
+        setTimeout(function() {
+          db.findKeys(KEY, null, function(err, keysFound) {
+            expect(keysFound).to.have.length(0);
+            done();
+          });
+        }, 1000);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Etherpad does not provide a callback when calling ueberdb "remove" operation,
so we need to handle this scenario on our side.

Fix #92