### PR TITLE
Support native UPSERTs & CrockroachDB

### DIFF
--- a/postgres_db.js
+++ b/postgres_db.js
@@ -55,6 +55,8 @@ exports.database.prototype.init = function(callback)
 			
   var _this = this;
   
+  _this.upsertStatement = "SELECT ueberdb_insert_or_update($1,$2)";
+  
   this.db.query(testTableExists, function(err, result) {
     if (result.rows.length == 0) {
   	  _this.db.query(createTable, callback);
@@ -117,7 +119,7 @@ exports.database.prototype.set = function (key, value, callback)
   }
   else
   {
-    this.db.query("SELECT ueberdb_insert_or_update($1,$2)", [key,value], callback);
+    this.db.query(_this.upsertStatement, [key,value], callback);
   }
 }
 
@@ -160,7 +162,7 @@ exports.database.prototype.doBulk = function (bulk, callback)
     {
       if (!replaceVALs.length < 1) {
         for (var v in replaceVALs) {
-          _this.db.query("SELECT ueberdb_insert_or_update($1,$2)", replaceVALs[v], callback);
+          _this.db.query(_this.upsertStatement, replaceVALs[v], callback);
         }
       } else {
         callback();

--- a/postgres_db.js
+++ b/postgres_db.js
@@ -39,18 +39,6 @@ exports.database.prototype.init = function(callback)
   			'"value" text NOT NULL, ' +
 			'CONSTRAINT store_pkey PRIMARY KEY (key))';
 			
-  var createFunc = "CREATE OR REPLACE FUNCTION ueberdb_insert_or_update(character varying, text) " +
-             "RETURNS void AS $$ " +
-             "BEGIN " +
-             "  IF EXISTS( SELECT * FROM store WHERE key = $1 ) THEN " +
-             "    UPDATE store SET value = $2 WHERE key = $1; " +
-             "  ELSE " +
-             "    INSERT INTO store(key,value) VALUES( $1, $2 ); " +
-             "  END IF; "+
-             "  RETURN; " +
-             "END; " +
-             "$$ LANGUAGE plpgsql;";
-			
   var _this = this;
   
   // this variable will be given a value depending on the result of the
@@ -69,6 +57,17 @@ exports.database.prototype.init = function(callback)
   function detectUpsertMethod(callback) {
     var upsertViaFunction = "SELECT ueberdb_insert_or_update($1,$2)";
     var upsertNatively    = "INSERT INTO store(key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = excluded.value";
+    var createFunc = "CREATE OR REPLACE FUNCTION ueberdb_insert_or_update(character varying, text) " +
+             "RETURNS void AS $$ " +
+             "BEGIN " +
+             "  IF EXISTS( SELECT * FROM store WHERE key = $1 ) THEN " +
+             "    UPDATE store SET value = $2 WHERE key = $1; " +
+             "  ELSE " +
+             "    INSERT INTO store(key,value) VALUES( $1, $2 ); " +
+             "  END IF; "+
+             "  RETURN; " +
+             "END; " +
+             "$$ LANGUAGE plpgsql;";
     
     var testNativeUpsert = "EXPLAIN " + upsertNatively;
 


### PR DESCRIPTION
Currently, when running on Postgres, UeberDB emulates UPSERTS operations on the key/value store via a pgsl function.

In 2016, with version 9.5, **[PostgreSQL](https://en.wikipedia.org/wiki/PostgreSQL#Release_history)** gained the ability of natively performing UPSERTS on tables, via the SQL construct [```ON CONFLICT ... DO UPDATE```](https://www.postgresql.org/docs/9.5/static/sql-insert.html#SQL-ON-CONFLICT).

**[CockroachDB](https://www.cockroachlabs.com/)**, being externally modeled after PostgreSQL, also [offers the same syntax](https://www.cockroachlabs.com/docs/stable/upsert.html#how-upsert-transforms-into-insert-on-conflict).
As of version 1.x, CockroachDB does _not_ support user defined functions.

This patch series aims to remove the use of the custom sql function ```ueberdb_insert_or_update()``` for performing upserts, and instead uses native statements when available.

The decision on using the upsert syntax or the sql function is taken based on feature detection, and not version sniffing.

The effects are:
- no changes for PostgreSQL <= 9.4
- performance improvements for PostgreSQL >= 9.5
- support of CockroachDB

The code was tested with:
- PostgreSQL 9.4 (falls back to the old behaviour)
- PostgreSQL 9.5 (uses native statements)
- CockroachDB 1.0.5 (works as above)
