### PR TITLE
Allow option for setting cache limit

### DIFF
--- a/postgres_db.js
+++ b/postgres_db.js
@@ -21,7 +21,7 @@ exports.database = function(settings)
 {
   this.settings = settings;
 
-  this.settings.cache = 1000;
+  this.settings.cache = settings.cache || 1000;
   this.settings.writeInterval = 100;
   this.settings.json = true;
 


### PR DESCRIPTION
Cache setting should be under the control of client using ueberdb