### PR TITLE
Fix remove(key) not removing from storage - https://github.com/Pita/ueberDB/issues/105

### DIFF
--- a/CacheAndBufferLayer.js
+++ b/CacheAndBufferLayer.js
@@ -209,22 +209,10 @@ exports.database.prototype.findKeys = function(key, notKey, callback){
  * Remove a record from the database
  */
 exports.database.prototype.remove = function(key, callback){
-  var self = this;
-  this.wrappedDB.remove(key, function(err)
-  {
-    // Remove the key from the buffer so that it's not flushed to DB whenever the flush decides to run.
-    // Fixes https://github.com/Pita/ueberDB/issues/105 which was caused by https://github.com/tiblu/ueberDB/commit/86ced9b3999ca6e46ec73bb93f6d9b1ec730d1b0
-    if (!err) {
-      delete self.buffer[key];
-    }
+  this.logger.debug("DELETE - " + key + " - from database ");
 
-    //call the garbage collector
-    self.gc();
-    self.logger.debug("DELETE - " + key + " - from database ");
-
-    callback(err);
-  });
-}
+  this.set(key, null, callback);
+};
 
 /**
  Sets the value trough the wrapper

--- a/CacheAndBufferLayer.js
+++ b/CacheAndBufferLayer.js
@@ -212,6 +212,12 @@ exports.database.prototype.remove = function(key, callback){
   var self = this;
   this.wrappedDB.remove(key, function(err)
   {
+    // Remove the key from the buffer so that it's not flushed to DB whenever the flush decides to run.
+    // Fixes https://github.com/Pita/ueberDB/issues/105 which was caused by https://github.com/tiblu/ueberDB/commit/86ced9b3999ca6e46ec73bb93f6d9b1ec730d1b0
+    if (!err) {
+      delete self.buffer[key];
+    }
+
     //call the garbage collector
     self.gc();
     self.logger.debug("DELETE - " + key + " - from database ");


### PR DESCRIPTION
**NOTE:** It's partially reverting @JohnMcLear  -s commit https://github.com/Pita/ueberDB/commit/86ced9b3999ca6e46ec73bb93f6d9b1ec730d1b0 and it means it **MAY break the crate_db removal functionality**. We @JohnMcLear input on this one.

Had no better idea how to fix this tho, see details on the symptoms - https://github.com/Pita/ueberDB/issues/105