### PR TITLE
Security updates for mysql and elasticsearch + bump to 0.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Abstract your databases, make datababies.  ueberDB turns every database into a s
 * Elasticsearch
 * Level
 * Mongo
-* MySQL
+* MySQL (<= 5.7)
 * Postgres
 * Redis
 * RethinkDB

--- a/elasticsearch_db.js
+++ b/elasticsearch_db.js
@@ -21,6 +21,9 @@ var elasticsearchSettings = {
   hostname      : '127.0.0.1',
   port          : '9200',
   base_index    : 'ueberes',
+  
+  // for a list of valid API values see:
+  // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-options
   api           : '2.4'
 };
 

--- a/elasticsearch_db.js
+++ b/elasticsearch_db.js
@@ -21,7 +21,7 @@ var elasticsearchSettings = {
   hostname      : '127.0.0.1',
   port          : '9200',
   base_index    : 'ueberes',
-  api           : '1.5'
+  api           : '2.4'
 };
 
 var client;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "http://github.com/pita/ueberDB.git"
   },
   "main": "./CloneAndAtomicLayer",
-  "version": "0.3.7",
+  "version": "0.3.9",
   "gitHead": "00cb8c896433922111c12fe9d2a45087fdb11d59",
   "bugs": {
     "url": "https://github.com/pita/ueberDB/issues"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cassandra-driver": "2.0.1",
     "channels": "0.0.4",
     "dirty": "0.9.x",
-    "elasticsearch": "11.0.1",
+    "elasticsearch": "15.1.1",
     "mysql": "2.15.0",
     "nano": "^6.2.0",
     "pg": "~6.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "channels": "0.0.4",
     "dirty": "0.9.x",
     "elasticsearch": "11.0.1",
-    "mysql": "2.6.1",
+    "mysql": "2.15.0",
     "nano": "^6.2.0",
     "pg": "~6.1.6",
     "redis": ">=0.12.1",


### PR DESCRIPTION
* Version 2.6.1 of mysql library is from 2015, and has a Remote Memory Exposure vulnerability (see ether/etherpad-lite#3397).
This change updates the library at its latest version as of today (2.15.0).
Tested against mysql 5.7 with no evident regressions.
Since mysql 8 is not supported yet, let's document it in the README

* The Elasticsearch library depends on an old version of lodash, which causes a *Prototype Pollution* warning in `npm audit` which requires manual intervention.

* let's bump the version to **0.3.9**. This would include these change, plus the security fix merged with #112 